### PR TITLE
winetricks-git still has a makedepends on git

### DIFF
--- a/winetricks-git/PKGBUILD
+++ b/winetricks-git/PKGBUILD
@@ -1,24 +1,25 @@
 # Maintainer: M0Rf30
 # Contributor: Eschwartz <eschwartz93@gmail.com>
- 
+
 pkgname=winetricks-git
-pkgver=20150316
+pkgver=20150416.r2.gd5bae62
 pkgrel=1
 pkgdesc='Script to install various redistributable runtime libraries in Wine.'
 url='http://wiki.winehq.org/winetricks'
 license=('LGPL')
 arch=('any')
 depends=('wine' 'cabextract' 'unzip' 'xorg-xmessage' 'wget')
-makedepends=('subversion')
+makedepends=('git')
 optdepends=('zenity: GUI for GNOME desktop'
             'kdebase-kdialog: GUI for KDE desktop')
 conflicts=('winetricks' 'bin32-winetricks')
 replaces=('bin32-winetricks' 'winetricks')
 provides=('winetricks')
-_gitmod='winetricks'
 source=("https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks"
         "https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks.1")
- 
+md5sums=('SKIP'
+         'SKIP')
+
 pkgver() {
     awk 'BEGIN {
            FS = "[ /^]+"
@@ -27,17 +28,14 @@ pkgver() {
                    sha = substr($0, 1, 7)
                tag = $3
            }
-           while ("curl -s https://Github.com/Winetricks/winetricks/releases/tag/" tag | getline)
+           while ("curl -s https://github.com/Winetricks/winetricks/releases/tag/" tag | getline)
                if ($3 ~ "commits")
                    com = $2
-           printf com ? "%s-%s-g%s\n" : "%s\n", tag, com, sha
-       }' | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+           printf com ? "%s.r%s.g%s\n" : "%s\n", tag, com, sha
+       }'
 }
- 
+
 package() {
   install -Dm755 ${srcdir}/winetricks ${pkgdir}/usr/bin/winetricks
   install -Dm755 ${srcdir}/winetricks.1 ${pkgdir}/usr/share/man/man1/winetricks.1
 }
- 
-md5sums=('SKIP'
-         'SKIP')


### PR DESCRIPTION
Updating the version still uses git ls-remote.
Also, subversion hasn't been used for a while now. ;)