### PR TITLE
Fix PKGBUILD to install Leap.py and LeapPython.so correctly

### DIFF
--- a/leap-motion-sdk/PKGBUILD
+++ b/leap-motion-sdk/PKGBUILD
@@ -43,8 +43,8 @@ package() {
   cp LeapSDK/lib/LeapCSharp.NET{3.5,4.0}.dll ${pkgdir}/usr/lib/Leap
 
   ln -s "/usr/lib/Leap/libLeap.so" "${pkgdir}/usr/lib/libLeap.so"
-  install -D -m644 "/usr/lib/Leap/Leap.py" "${pkgdir}/usr/lib/python2.7/site-packages/Leap.py"
-  install -D -m644 "/usr/lib/Leap/LeapPython.so" "${pkgdir}/usr/lib/python2.7/site-packages/LeapPython.so"
+  install -D -m644 "${pkgdir}/usr/lib/Leap/Leap.py" "${pkgdir}/usr/lib/python2.7/site-packages/Leap.py"
+  install -D -m644 "${pkgdir}/usr/lib/Leap/LeapPython.so" "${pkgdir}/usr/lib/python2.7/site-packages/LeapPython.so"
 
   install -D -m644 "${srcdir}"/libleap.pc "${pkgdir}/usr/lib/pkgconfig/libleap.pc"
   # Copy license


### PR DESCRIPTION
Saw the issue while running `makepkg`:

    install: cannot stat ‘/usr/lib/Leap/Leap.py’: No such file or directory
    ==> ERROR: A failure occurred in package().

DevPump suggested a fix in the comments in the package page in AUR. This PR follows his suggestion and fixed the error.