### PR TITLE
cie-middleware-git: revision

### DIFF
--- a/cie-middleware-git/PKGBUILD
+++ b/cie-middleware-git/PKGBUILD
@@ -1,16 +1,15 @@
 # Maintainer: robertfoster
 
 pkgname=cie-middleware-git
-pkgver=1.3.1.r0.12716c4
-pkgrel=1
+pkgver=1.3.1.r1.5d96db4
+pkgrel=2
 pkgdesc="Middleware della CIE (Carta di Identità Elettronica) per Linux (mio fork)"
-arch=('any')
+arch=(x86_64 i686 pentium4 arm armv6h armv7h aarch64)
 url="https://developers.italia.it/it/cie"
 license=('BSD')
-depends=('crypto++' 'openssl' 'pcsclite')
-makedepends=('gradle')
+depends=('crypto++' 'openssl' 'pcsclite' 'java-environment')
+makedepends=('git' 'gradle')
 install="${pkgname%-git}.install"
-_shortname=cieid
 
 source=("${pkgname%-git}::git+https://github.com/M0Rf30/${pkgname%-git}-linux")
 


### PR DESCRIPTION
Hello

* corrected arch, not an 'any' package
* missing git as makedepends
* need java-environment to run
* removed unused custom variable