### PR TITLE
iortcw-git: Add build() function - fixes #12

### DIFF
--- a/iortcw-git/PKGBUILD
+++ b/iortcw-git/PKGBUILD
@@ -32,6 +32,19 @@ pkgver() {
   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
+build() {
+	cd "$srcdir/iortcw"
+
+    # make SP
+	cd SP
+	make USE_INTERNAL_LIBS=0
+
+
+    # make MP
+    cd ../MP
+    make USE_INTERNAL_LIBS=0
+}
+
 package() {
   cd "$srcdir/iortcw"
 


### PR DESCRIPTION
This fixes building with tools that break under fakeroot, such as
ccache. See #12  for some details

ccache ends up fooled to use `/run/user/0/ccache-tmp` - a directory it
has no access to. The reason is that makepkg automatically uses
fakeroot to run commands under package(), to fool any installation
tools that may be so foolish as to require root privileges to install
into a non-root directory (`$pkgdir`).

This probably fixes other things too, but I wouldn't know.