### PR TITLE
winetricks-git pkgver error fix

### DIFF
--- a/winetricks-git/PKGBUILD
+++ b/winetricks-git/PKGBUILD
@@ -19,7 +19,7 @@ source=("$pkgname::git+https://github.com/Winetricks/winetricks.git")
 
 pkgver() {
   cd "$pkgname"
-  git describe --long --tags | sed -r 's/-([0-9]+)-/.r\1./'
+  git describe --long --tags | sed 's/^[v-]//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 package() {


### PR DESCRIPTION
make small changes of pkgver syntax to fix such an error below
`ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace`