### PR TITLE
Remove xorg-xmessage from winetricks depends

### DIFF
--- a/winetricks-git/PKGBUILD
+++ b/winetricks-git/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='Script to install various redistributable runtime libraries in Wine.'
 url='http://wiki.winehq.org/winetricks'
 license=('LGPL-2.1-or-later')
 arch=('any')
-depends=('wine' 'cabextract' 'unzip' 'xorg-xmessage')
+depends=('wine' 'cabextract' 'unzip')
 makedepends=('git')
 optdepends=('zenity: For the GTK3 GUI.'
   'kdialog: For the KDE GUI (less capable).'


### PR DESCRIPTION
`xmessage` is not properly supported in winetricks script.