### PR TITLE
libcuda.so.1 is in nvidia-utils

### DIFF
--- a/whisper.cpp-cuda/PKGBUILD
+++ b/whisper.cpp-cuda/PKGBUILD
@@ -8,7 +8,8 @@ pkgdesc="Port of OpenAI's Whisper model in C/C++ (with NVIDIA CUDA optimizations
 arch=('armv7h' 'aarch64' 'x86_64')
 url="https://github.com/ggerganov/whisper.cpp"
 license=("MIT")
-depends=('cuda')
+depends=('cuda'
+         'nvidia-utils')
 conflicts=("${_pkgbase}")
 provides=("${_pkgbase}")
 makedepends=(


### PR DESCRIPTION
`whisper.cpp-cuda` depends on `libcuda.so.1`, which is in pkg `nvidia-utils`