### PR TITLE
easyeffects-git: update makedepends using 'appstream'

### DIFF
--- a/easyeffects-git/PKGBUILD
+++ b/easyeffects-git/PKGBUILD
@@ -35,7 +35,7 @@ depends=(
   'webrtc-audio-processing'
   'zita-convolver'
 )
-makedepends=('appstream-glib' 'cmake' 'extra-cmake-modules' 'git' 'intltool' 'ladspa' 'ninja')
+makedepends=('appstream' 'cmake' 'extra-cmake-modules' 'git' 'intltool' 'ladspa' 'ninja')
 optdepends=(
   'calf: limiter, exciter, bass enhancer and others'
   'lsp-plugins: equalizer, compressor, delay, loudness'


### PR DESCRIPTION
Easy Effects does not use `appstream-util` anymore.

Please, update on AUR.