### PR TITLE
easyeffects-git: add breeze as optional dependency

### DIFF
--- a/easyeffects-git/PKGBUILD
+++ b/easyeffects-git/PKGBUILD
@@ -38,6 +38,7 @@ depends=(
 )
 makedepends=('appstream' 'cmake' 'extra-cmake-modules' 'git' 'intltool' 'ladspa' 'ninja')
 optdepends=(
+  'breeze: KDE breeze style'
   'calf: limiter, exciter, bass enhancer and others'
   'lsp-plugins: equalizer, compressor, delay, loudness'
   'zam-plugins: maximizer'

--- a/easyeffects-git/PKGBUILD
+++ b/easyeffects-git/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Wellington <wellingtonwallace@gmail.com>
 
 pkgname=easyeffects-git
-pkgver=7.1.7.r1478.g0c61490fe
+pkgver=8.0.0.r0.g2a3986ca4
 pkgrel=1
 pkgdesc='Audio Effects for PipeWire applications'
 arch=(x86_64 i686 arm armv6h armv7h aarch64)
@@ -28,6 +28,7 @@ depends=(
   'qqc2-desktop-style'
   'qt6-base'
   'qt6-graphs'
+  'qt6-webengine'
   'rnnoise'
   'soundtouch'
   'speexdsp'

--- a/easyeffects-git/PKGBUILD
+++ b/easyeffects-git/PKGBUILD
@@ -35,7 +35,7 @@ depends=(
   'webrtc-audio-processing'
   'zita-convolver'
 )
-makedepends=('appstream-glib' 'cmake' 'extra-cmake-modules' 'git' 'intltool' 'ladspa' 'ninja')
+makedepends=('appstream' 'cmake' 'extra-cmake-modules' 'git' 'intltool' 'ladspa' 'ninja')
 optdepends=(
   'calf: limiter, exciter, bass enhancer and others'
   'lsp-plugins: equalizer, compressor, delay, loudness'


### PR DESCRIPTION
KDE `breeze` theme is an optional dependency for Easy Effects. See https://github.com/wwmm/easyeffects/blob/master/PKGBUILD_AUR