### PR TITLE
update stable-diffusion PKGBUILDs

### DIFF
--- a/stable-diffusion.cpp-cublas-git/PKGBUILD
+++ b/stable-diffusion.cpp-cublas-git/PKGBUILD
@@ -10,13 +10,13 @@ license=("MIT")
 depends=('cuda')
 makedepends=(
   'cmake'
-  'gcc13'
+  'gcc'
   'git'
 )
 conflicts=("${pkgname%%-git}" 'stable-diffusion.cpp')
 provides=("${pkgname%%-git}" 'stable-diffusion.cpp')
 source=("${pkgname%%-git}::git+${url}"
-  "git+https://github.com/ggerganov/ggml.git#commit=ff9052988b76e137bcf92bb335733933ca196ac0")
+  "git+https://github.com/ggml-org/ggml")
 
 pkgver() {
   cd "${srcdir}/${pkgname%%-git}"
@@ -33,13 +33,14 @@ prepare() {
 
 build() {
   export PATH+=":/opt/cuda/bin"
-  export NVCC_CCBIN="gcc-13"
+  export NVCC_CCBIN="gcc"
   cmake \
     -B "${srcdir}/build" \
     -S "${srcdir}/${pkgname%%-git}" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
-    -DGGML_CUDA=1
+    -DGGML_CUDA=ON \
+    -DSD_CUDA=ON
 
   cmake --build build
 }

--- a/stable-diffusion.cpp-git/PKGBUILD
+++ b/stable-diffusion.cpp-git/PKGBUILD
@@ -36,7 +36,7 @@ build() {
     -S "${srcdir}/${pkgname%%-git}" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
-    -DGGML_BLAS=1 \
+    -DGGML_BLAS=ON \
     -DGGML_BLAS_VENDOR=OpenBLAS
 
   cmake --build build

--- a/stable-diffusion.cpp-hipblas-git/PKGBUILD
+++ b/stable-diffusion.cpp-hipblas-git/PKGBUILD
@@ -42,7 +42,8 @@ build() {
     -S "${srcdir}/${pkgname%%-git}" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
-    -DGGML_HIP=1
+    -DGGML_HIP=ON \
+    -DSD_HIPBLAS=ON
 
   cmake --build build
 }

--- a/stable-diffusion.cpp-sycl-f16-git/PKGBUILD
+++ b/stable-diffusion.cpp-sycl-f16-git/PKGBUILD
@@ -39,7 +39,8 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=icx \
     -DCMAKE_CXX_COMPILER=icpx \
-    -DGGML_SYCL_F16=1
+    -DGGML_SYCL=ON \
+    -DGGML_SYCL_F16=ON
 
   cmake --build build
 }

--- a/stable-diffusion.cpp-sycl-f32-git/PKGBUILD
+++ b/stable-diffusion.cpp-sycl-f32-git/PKGBUILD
@@ -39,7 +39,7 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=icx \
     -DCMAKE_CXX_COMPILER=icpx \
-    -DGGML_SYCL=1
+    -DGGML_SYCL=ON
 
   cmake --build build
 }


### PR DESCRIPTION
### Notable changes

`stable-diffusion.cpp-cublas-git/PKGBUILD`:
- use latest `gcc` in `makedepends`
- reference the latest GitHub repo `git+https://github.com/ggml-org/ggml`, previous one was referencing an old commit
- change `-DGGML_CUDA` value to `ON` to be consistent with `llama.cpp` docs
- add `-DSD_CUDA=ON` (specific to `stable-diffusion.cpp`, needed to enable GPU acceleration)

`stable-diffusion.cpp-git/PKGBUILD`:
- change `-DGGML_BLAS` value to `ON` to be consistent with `llama.cpp` docs

`stable-diffusion.cpp-hipblas-git/PKGBUILD`:
- change `-DGGML_HIP` value to `ON` to be consistent with `llama.cpp` docs
- add `-DSD_HIPBLAS=ON` (specific to `stable-diffusion.cpp`, needed to enable GPU acceleration)

`stable-diffusion.cpp-sycl-f16-git/PKGBUILD`
- change `-DGGML_SYCL` value to `ON` to be consistent with `llama.cpp` docs
- add `-DGGML_SYCL_F16=ON` (specific to `stable-diffusion.cpp`, needed to enable GPU acceleration)

`stable-diffusion.cpp-sycl-f32-git/PKGBUILD`:
- change `-DGGML_SYCL` value to `ON` to be consistent with `llama.cpp` docs

I've tested `stable-diffusion.cpp-cublas-git/PKGBUILD` changes and the package builds successfully with GCC 15 / Cuda 13. The others I have not yet tested, but changes should be non-breaking since these are from the official docs.