### PR TITLE
fix(openspec): allow esbuild build scripts for pnpm 10+ compatibility

### DIFF
--- a/openspec/PKGBUILD
+++ b/openspec/PKGBUILD
@@ -13,6 +13,11 @@ sha256sums=('0cf70e2154afab8410930f3540b42193c05557dded04a7dbef848f2f63ec1405')
 
 prepare() {
   cd "${srcdir}/OpenSpec-${pkgver}"
+  # Allow esbuild's postinstall script to download platform binary
+  cat > pnpm-workspace.yaml << 'EOF'
+allowBuilds:
+  esbuild: true
+EOF
   # Install dependencies without building yet
   pnpm install --no-frozen-lockfile
 }


### PR DESCRIPTION
## Problem

`makepkg -sif` fails in `prepare()` — tracked in #446.

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.8

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
==> ERROR: A failure occurred in prepare().
```

The OpenSpec release tarball (v1.4.1) does not ship a `pnpm-workspace.yaml`.
pnpm 10+ introduced a security feature: unless a workspace config explicitly
approves a dependency's build scripts, they are blocked and `pnpm install`
exits with a non-zero code.

`esbuild@0.25.8` is pulled in as a transitive dependency (`vitest` → `vite`).
Its postinstall script downloads a platform-specific native binary. Even
though the TypeScript compilation (`node build.js`) does not invoke esbuild
directly, pnpm still treats the unapproved script as a fatal condition.

## Fix

Create a minimal `pnpm-workspace.yaml` in `prepare()` before `pnpm install`
to approve esbuild's build script explicitly:

```yaml
allowBuilds:
  esbuild: true
```

This is exactly how the upstream project intended the config to be used
(their pre-built Nix flake uses the same pattern). The file is not
gitignored by upstream (`.gitignore` only ignores `.pnpm-store/`).

## Verification

Tested with a clean build (`rm -rf src pkg && makepkg -sif`):
- `prepare()` completes without `ERR_PNPM_IGNORED_BUILDS`
- `build()` compiles TypeScript successfully
- `package()` creates a working package
- `openspec --version` confirms the CLI is functional

## Future cleanup

Once upstream commits their own `pnpm-workspace.yaml` (tracked in
Fission-AI/OpenSpec#1195), the `cat > pnpm-workspace.yaml` workaround
can be removed from the PKGBUILD.
